### PR TITLE
Make Client Credentials Secret optional for use with PKCE

### DIFF
--- a/lib/src/model/oauth2_client_credentials.dart
+++ b/lib/src/model/oauth2_client_credentials.dart
@@ -4,8 +4,8 @@ class OAuth2ClientCredentials {
   final String id;
 
   /// The client secret
-  final String secret;
+  final String? secret;
 
   /// Constructor
-  const OAuth2ClientCredentials({required this.id, required this.secret});
+  const OAuth2ClientCredentials({required this.id, this.secret});
 }

--- a/lib/src/model/oauth2_endpoints.dart
+++ b/lib/src/model/oauth2_endpoints.dart
@@ -40,13 +40,13 @@ class OAuth2Endpoints {
     String base, {
     String authorization = 'authorize',
     String token = 'token',
-    String revocation = 'revoke',
-    String endSession = 'end_session',
+    String? revocation = 'revoke',
+    String? endSession = 'end_session',
   }) : this(
           authorization: '$base/$authorization',
           token: '$base/$token',
-          revocation: '$base/$revocation',
-          endSession: '$base/$endSession',
+          revocation: revocation != null ? '$base/$revocation' : null,
+          endSession: endSession != null ? '$base/$endSession' : null,
         );
 
   /// From json

--- a/lib/src/model/oauth2_endpoints.dart
+++ b/lib/src/model/oauth2_endpoints.dart
@@ -40,13 +40,13 @@ class OAuth2Endpoints {
     String base, {
     String authorization = 'authorize',
     String token = 'token',
-    String? revocation = 'revoke',
-    String? endSession = 'end_session',
+    String revocation = 'revoke',
+    String endSession = 'end_session',
   }) : this(
           authorization: '$base/$authorization',
           token: '$base/$token',
-          revocation: revocation != null ? '$base/$revocation' : null,
-          endSession: endSession != null ? '$base/$endSession' : null,
+          revocation: '$base/$revocation',
+          endSession: '$base/$endSession',
         );
 
   /// From json

--- a/lib/src/oauth_flutter_base.dart
+++ b/lib/src/oauth_flutter_base.dart
@@ -160,11 +160,12 @@ class OAuth2Client<T extends SecureOAuth2Token> {
 
   Map<String, String> get _tokenHeaders {
     final credentials = this.credentials;
+    final secret = credentials?.secret;
     return {
       'Content-Type': 'application/x-www-form-urlencoded',
-      if (credentials != null && credentials.secret != null)
+      if (credentials != null && secret != null)
         'Authorization':
-            'Basic ${base64Encode(utf8.encode('${credentials.id}:${credentials.secret}'))}',
+            'Basic ${base64Encode(utf8.encode('${credentials.id}:$secret'))}',
     };
   }
 

--- a/lib/src/oauth_flutter_base.dart
+++ b/lib/src/oauth_flutter_base.dart
@@ -162,7 +162,7 @@ class OAuth2Client<T extends SecureOAuth2Token> {
     final credentials = this.credentials;
     return {
       'Content-Type': 'application/x-www-form-urlencoded',
-      if (credentials != null)
+      if (credentials != null && credentials.secret != null)
         'Authorization':
             'Basic ${base64Encode(utf8.encode('${credentials.id}:${credentials.secret}'))}',
     };


### PR DESCRIPTION
To address #4, I made the Client Credentials Secret optional and don't send it as Authorization Header in the token request when using PKCE.
Additionally, made the revocation and endSession parameters of the OAuth2Endpoints.base factory constructor optional as they are optional in the regular constructor as well.