### PR TITLE
await refresh method for proper error handling

### DIFF
--- a/lib/src/oauth_flutter_base.dart
+++ b/lib/src/oauth_flutter_base.dart
@@ -139,7 +139,7 @@ class OAuth2Client<T extends SecureOAuth2Token> {
   Future<T> _refreshToken({
     required T? oldToken,
     required ReAuthenticationCallback<T> onReAuthenticate,
-  }) {
+  }) async {
     Future<T> reauthenticate() async {
       final token = await onReAuthenticate();
       if (token == null) throw Exception('Re-authenticate returned no token');
@@ -149,7 +149,7 @@ class OAuth2Client<T extends SecureOAuth2Token> {
     if (oldToken == null) return reauthenticate();
 
     try {
-      return refresh(token: oldToken);
+      return await refresh(token: oldToken);
     } on DioException catch (e) {
       final statusCode = e.response?.statusCode;
       if (statusCode == null) rethrow;


### PR DESCRIPTION
When refresh token was expired, a future was being returned from the dio refresh post. This (the refresh method) wasn't being awaited, causing the catch to not catch the error.